### PR TITLE
Fix: 2FA login returns to login page after entering correct code

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -106,7 +106,9 @@ export async function authRoutes(fastify: FastifyInstance) {
         db.prepare('UPDATE users SET twofa_code = NULL, twofa_expires = NULL WHERE id = ?').run(userId);
         // Issue JWT
         const token = jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET as string, { expiresIn: '1h' });
-        reply.send({ message: '2FA verified. Login successful.', token });
+        // Return user info (without password) so frontend can set context
+        const { password, ...userWithoutPassword } = user;
+        reply.send({ message: '2FA verified. Login successful.', token, user: userWithoutPassword });
     });
 
     // Google Sign-In

--- a/frontend/src/context/PlayerContext.tsx
+++ b/frontend/src/context/PlayerContext.tsx
@@ -56,6 +56,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     setPlayerState(null);
     setIsLoggedIn(false);
     localStorage.removeItem('player');
+    localStorage.removeItem('token');
   };
   
   const setPlayer = (playerData: Player | null) => {

--- a/frontend/src/pages/TwoFactorAuth.tsx
+++ b/frontend/src/pages/TwoFactorAuth.tsx
@@ -10,7 +10,7 @@ export default function TwoFactorAuth() {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
-  const { setIsLoggedIn } = usePlayer();
+  const { login, setIsLoggedIn } = usePlayer();
 
   // Retrieve the userId passed from the login page
   const userId = (location.state as { userId: string })?.userId;
@@ -23,7 +23,19 @@ export default function TwoFactorAuth() {
     try {
       const res = await authService.verify2FA(userId, code);
       localStorage.setItem("token", res.token);
-      setIsLoggedIn(true);
+      if (res.user) {
+        login({
+          id: res.user.id,
+          email: res.user.email,
+          username: res.user.username,
+          avatar: res.user.avatar,
+          language: res.user.language || 'en',
+          provider: res.user.googleId ? 'google' : undefined,
+        });
+      } else {
+        // Fallback: minimal login state if user is not returned (shouldn't happen now)
+        setIsLoggedIn(true);
+      }
       navigate("/");
     } catch (err: any) {
       setError(err.message || t("invalidCode") || "Invalid verification code");

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -54,15 +54,13 @@ function AnimatedRoutes() {
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((user) => {
-      if (user) {
-        // This logic will now be handled by our backend login flow,
-        // but we can keep it for the initial Google popup.
-        // The actual app state is set via the login() function in the context.
-      } else {
-        // When Firebase detects a logout, we ensure our app state is also cleared.
+      // Guard against clearing backend-authenticated sessions
+      const hasBackendToken = !!localStorage.getItem('token');
+      if (!user && !hasBackendToken) {
         setIsLoggedIn(false);
         setPlayer(null);
       }
+      // If firebase has a user, leave context changes to explicit login() calls
     });
     return () => unsubscribe();
   }, [setIsLoggedIn, setPlayer]);


### PR DESCRIPTION
Issue:
- After entering the correct 2FA code, the app goes back to the login page and the user is not logged in.

Cause:
- Firebase auth listener cleared app state when no Firebase session.
- backend /api/auth/verify-2fa did not return user data for the frontend to set context.

Changes:
- Backend verify-2fa now returns {token, user}
- frontend TwoFactorAuth saves token and calls login(user)
- router ignores Firebase onAuthStateChanged logout if a backend JWT exists
- logout removes JWT.

Test result:
- Login -> receive 2FA email -> enter correct code -> stay logged in on Home
- protected routes accessible
- localStorage has token and player.

@Juliettemtte 
Resolves #8