### PR TITLE
Remove auto-login on registration; redirect SignUp to login

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -55,29 +55,10 @@ export async function authRoutes(fastify: FastifyInstance) {
 
             //**** stmt.run(id, email, username, hashedPassword, DEFAULT_AVATAR);
 
-            
-            // Generate JWT immediately for new users (no 2FA required for registration)
-            const token = jwt.sign({ id, email: sanitizedEmail }, process.env.JWT_SECRET as string, { expiresIn: '1h' });
-            
-            // Return user info (without password) and token
-            const newUser = {
-                id,
-
-                email: sanitizedEmail,
-                username: sanitizedUsername,
-               //**** avatar: defaultAvatar,
-
-               //**** email,
-               //**** username,
-                avatar: DEFAULT_AVATAR,
-
-                language: 'en' // default language
-            };
-            
+            // Return success message without issuing a JWT token.
+            // Users must log in and complete 2FA before receiving a JWT.
             reply.status(201).send({ 
-                message: 'User registered successfully', 
-                token, 
-                user: newUser 
+                message: 'User registered successfully. Please log in to continue.'
             });
         } catch (error: any) {
             if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -30,12 +30,11 @@ export default function SignUp() {
     setLoading(true);
 
     try {
-      // Register user and get immediate login (no 2FA for registration)
-      const { token, user } = await authService.register(email, username, password);
+      // Register user; backend no longer returns a token or user on signup
+      await authService.register(email, username, password);
 
-      localStorage.setItem('token', token);
-      login(user);
-      navigate('/completeprofile');
+      // Redirect to login page to proceed with 2FA-protected login
+      navigate('/register', { state: { registered: true, email } });
     } catch (err: any) {
       setError(err.message || t('signUpError'));
     } finally {


### PR DESCRIPTION
After a user registers, we are no longer allowing them to simultaneously log in, but rather we are directing them to the login page. The reasoning is, we don't have 2FA at the registration, so we shouldn't let them log in. They can then use their credentials and their 2FA code to log in.