### PR TITLE
Protect missing routes with JWT and harden 2FA codes

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -94,8 +94,8 @@ export async function authRoutes(fastify: FastifyInstance) {
             return reply.status(401).send({ message: 'Invalid credentials' });
         }
 
-        // Generate 2FA code
-        const twofaCode = Math.floor(100000 + Math.random() * 900000).toString(); // 6-digit code
+        // Generate 2FA code using crypto.randomInt for stronger randomness
+        const twofaCode = String(crypto.randomInt(0, 1_000_000)).padStart(6, '0'); // 6-digit code
         const twofaExpires = new Date(Date.now() + 10 * 60 * 1000).toISOString(); // 10 minutes from now
         db.prepare('UPDATE users SET twofa_code = ?, twofa_expires = ?, twofa_enabled = 1 WHERE id = ?')
           .run(twofaCode, twofaExpires, user.id);

--- a/backend/src/routes/friendRoutes.ts
+++ b/backend/src/routes/friendRoutes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db } from "../db/database";
+import { jwtMiddleware } from "../jwtMiddleware";
 
 // ------------------ TYPES ------------------
 type UserIdParams = { userId: string };
@@ -27,10 +28,11 @@ export default async function friendRoutes(fastify: FastifyInstance) {
    * 📌 GET /api/friends/:userId
    * Returns the full list of friends for a given user.
    */
-  fastify.get(
+  fastify.get<{ Params: UserIdParams }>(
     "/",
+    { preHandler: [jwtMiddleware] },
     async (
-      request: FastifyRequest<{ Params: UserIdParams }>,
+      request,
       reply: FastifyReply
     ) => {
       const { userId } = request.params;
@@ -63,13 +65,11 @@ export default async function friendRoutes(fastify: FastifyInstance) {
    * - The current user (cannot friend yourself)
    * - Already added friends
    */
-	fastify.get(
+	fastify.get<{ Params: UserIdParams; Querystring: { q?: string } }>(
 	"/search",
+	{ preHandler: [jwtMiddleware] },
 	async (
-		request: FastifyRequest<{
-		Params: UserIdParams;
-		Querystring: { q?: string };
-		}>,
+		request,
 		reply: FastifyReply
 	) => {
 		const { userId } = request.params;
@@ -127,10 +127,11 @@ export default async function friendRoutes(fastify: FastifyInstance) {
    * 📌 POST /api/friends/:userId/:friendId
    * Add a new friend relation (bidirectional).
    */
-  fastify.post(
+  fastify.post<{ Params: UserIdParams & FriendIdParams }>(
     "/:friendId",
+    { preHandler: [jwtMiddleware] },
     async (
-      request: FastifyRequest<{ Params: UserIdParams & FriendIdParams }>,
+      request,
       reply: FastifyReply
     ) => {
       const { userId, friendId } = request.params;
@@ -168,10 +169,11 @@ export default async function friendRoutes(fastify: FastifyInstance) {
    * 📌 DELETE /api/friends/:userId/:friendId
    * Remove an existing friend relation (bidirectional).
    */
-  fastify.delete(
+  fastify.delete<{ Params: UserIdParams & FriendIdParams }>(
     "/:friendId",
+    { preHandler: [jwtMiddleware] },
     async (
-      request: FastifyRequest<{ Params: UserIdParams & FriendIdParams }>,
+      request,
       reply: FastifyReply
     ) => {
       const { userId, friendId } = request.params;
@@ -200,10 +202,11 @@ export default async function friendRoutes(fastify: FastifyInstance) {
    * 📌 GET /api/friends/:userId/:friendId/details
    * Get full profile of a friend + their last 10 matches.
    */
-  fastify.get(
+  fastify.get<{ Params: UserIdParams & FriendIdParams }>(
     "/:friendId/details",
+    { preHandler: [jwtMiddleware] },
     async (
-      request: FastifyRequest<{ Params: UserIdParams & FriendIdParams }>,
+      request,
       reply: FastifyReply
     ) => {
       const { friendId } = request.params;

--- a/backend/src/routes/matchRoutes.ts
+++ b/backend/src/routes/matchRoutes.ts
@@ -1,13 +1,14 @@
 import { FastifyInstance } from 'fastify';
 import net from 'net';
 import { startWsProxy } from '../wsProxy';
+import { jwtMiddleware } from '../jwtMiddleware';
 
 // This counter helps create unique WebSocket ports for each new game,
 // preventing conflicts if multiple games are running.
 let gameIdCounter = 0;
 
 export async function matchRoutes(fastify: FastifyInstance) {
-  fastify.post('/start', async (request, reply) => {
+  fastify.post('/start', { preHandler: [jwtMiddleware] }, async (request, reply) => {
     return new Promise((resolve, reject) => {
       const client = new net.Socket();
       let resolved = false;

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -170,7 +170,7 @@ export async function userRoutes(fastify: FastifyInstance) {
         }
     });
 
-    fastify.put('/:id', async (request: FastifyRequest, reply: FastifyReply) => {
+    fastify.put('/:id', { preHandler: [jwtMiddleware] }, async (request: FastifyRequest, reply: FastifyReply) => {
         const { id } = request.params as any;
 
         const parts = request.parts();


### PR DESCRIPTION
1) Add `jwtMiddleware` to:
- `friendRoutes`: all endpoints
- `matchRoutes`: POST /start
- `userRoutes`: PUT /:id
2) Generate 2FA codes with `crypto.randomInt(0, 1_000_000)` and zero‑pad to 6 digits
3) TypeScript fix: `friendRoutes` route generics for Fastify

Rationale: Ensure all auth-sensitive endpoints are protected per subject, improve OTP randomness.